### PR TITLE
Hash admin passwords and add migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,21 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 ---
 
-&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+&copy; 2025 GitHub • [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) • [MIT License](https://gh.io/mit)
 
+## Security: Hashing admin passwords (migration helper)
+
+This repository includes a helper to migrate plain-text admin passwords (from imported projects like the Sports Club example) into bcrypt hashes.
+
+- Script: `tools/migrate_admin_passwords.php` — run with PHP CLI.
+- Example login: `tools/secure_login_example.php` — demonstrates PDO + password_verify().
+
+Usage (example):
+
+```bash
+# export DB connection for the script
+export DB_HOST=127.0.0.1 DB_NAME=sports_club DB_USER=root DB_PASS=""
+php tools/migrate_admin_passwords.php
+```
+
+Make a DB backup before running the migration.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 This repository includes a helper to migrate plain-text admin passwords (from imported projects like the Sports Club example) into bcrypt hashes.
 
-- Script: `tools/migrate_admin_passwords.php` — run with PHP CLI.
-- Example login: `tools/secure_login_example.php` — demonstrates PDO + password_verify().
+- Script: `src/tools/migrate_admin_passwords.php` — run with PHP CLI.
+- Example login: `src/tools/secure_login_example.php` — demonstrates PDO + password_verify().
 
 Usage (example):
 
 ```bash
 # export DB connection for the script
 export DB_HOST=127.0.0.1 DB_NAME=sports_club DB_USER=root DB_PASS=""
-php tools/migrate_admin_passwords.php
+php src/tools/migrate_admin_passwords.php
 ```
 
 Make a DB backup before running the migration.

--- a/src/tools/migrate_admin_passwords.php
+++ b/src/tools/migrate_admin_passwords.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * migrate_admin_passwords.php
+ *
+ * One-time migration script to convert plain-text admin passwords
+ * into bcrypt hashes using PHP's password_hash().
+ *
+ * Usage (from project root):
+ *  php src/tools/migrate_admin_passwords.php
+ *
+ * REQUIREMENTS
+ * - PHP 7.4+ with PDO and PDO_MYSQL
+ * - A recent backup of your database (this script will update rows).
+ *
+ * The script will only hash passwords that don't already look like
+ * a bcrypt hash (checks prefix $2y$ or $2b$).
+ */
+
+// Read DB connection from environment variables for safety.
+$dbHost = getenv('DB_HOST') ?: '127.0.0.1';
+$dbName = getenv('DB_NAME') ?: 'sports_club';
+$dbUser = getenv('DB_USER') ?: 'root';
+$dbPass = getenv('DB_PASS') ?: '';
+$dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
+
+echo "\n== Admin password migration script ==\n";
+echo "This script will convert plain-text admin passwords into bcrypt hashes.\n";
+echo "Make sure you have a DB backup before proceeding.\n\n";
+
+$confirm = readline("Type 'YES' to continue: ");
+if (trim($confirm) !== 'YES') {
+    echo "Aborted. No changes made.\n";
+    exit(0);
+}
+
+try {
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+} catch (PDOException $e) {
+    fwrite(STDERR, "DB connection failed: " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$select = $pdo->query("SELECT id, username, pass_key FROM admin");
+$admins = $select->fetchAll(PDO::FETCH_ASSOC);
+
+if (!$admins) {
+    echo "No admin rows found in 'admin' table.\n";
+    exit(0);
+}
+
+$updated = 0;
+foreach ($admins as $row) {
+    $id = $row['id'];
+    $username = $row['username'];
+    $pass = $row['pass_key'];
+
+    // naive check for bcrypt hash: starts with $2y$ or $2b$
+    if (preg_match('/^\$2[aby]\$\d{2}\$/', $pass)) {
+        echo "[OK] id=$id username=$username already hashed.\n";
+        continue;
+    }
+
+    echo "Hashing password for id=$id username=$username... ";
+    $hash = password_hash($pass, PASSWORD_BCRYPT);
+    if ($hash === false) {
+        echo "FAILED\n";
+        continue;
+    }
+
+    $stmt = $pdo->prepare('UPDATE admin SET pass_key = :hash WHERE id = :id');
+    $stmt->execute([':hash' => $hash, ':id' => $id]);
+    echo "done.\n";
+    $updated++;
+}
+
+echo "\nMigration complete. $updated account(s) updated.\n";
+echo "Remember to revoke access to this script after use.\n";
+
+?>

--- a/src/tools/secure_login_example.php
+++ b/src/tools/secure_login_example.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * secure_login_example.php
+ *
+ * Minimal example showing how to safely authenticate an admin user
+ * using PDO prepared statements and password_verify().
+ *
+ * This is an example only — adapt paths, session handling and error
+ * management to your project.
+ */
+
+// Load DB settings from env (or replace with your config loader)
+$dbHost = getenv('DB_HOST') ?: '127.0.0.1';
+$dbName = getenv('DB_NAME') ?: 'sports_club';
+$dbUser = getenv('DB_USER') ?: 'root';
+$dbPass = getenv('DB_PASS') ?: '';
+$dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
+
+try {
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+} catch (PDOException $e) {
+    die('DB connection failed');
+}
+
+// Example: process POST login
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    $stmt = $pdo->prepare('SELECT id, username, pass_key FROM admin WHERE username = :username LIMIT 1');
+    $stmt->execute([':username' => $username]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($user && password_verify($password, $user['pass_key'])) {
+        // Regenerate session id, set session vars, etc.
+        session_start();
+        session_regenerate_id(true);
+        $_SESSION['admin_id'] = $user['id'];
+        $_SESSION['admin_user'] = $user['username'];
+        echo "Login OK\n";
+    } else {
+        echo "Invalid credentials\n";
+    }
+    exit;
+}
+
+// Simple HTML form for manual testing
+?>
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Login example</title></head>
+<body>
+<form method="post">
+  <label>Username: <input name="username"></label><br>
+  <label>Password: <input name="password" type="password"></label><br>
+  <button type="submit">Login</button>
+</form>
+</body>
+</html>

--- a/tools/migrate_admin_passwords.php
+++ b/tools/migrate_admin_passwords.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * migrate_admin_passwords.php
+ *
+ * One-time migration script to convert plain-text admin passwords
+ * into bcrypt hashes using PHP's password_hash().
+ *
+ * Usage (from project root):
+ *  php tools/migrate_admin_passwords.php
+ *
+ * REQUIREMENTS
+ * - PHP 7.4+ with PDO and PDO_MYSQL
+ * - A recent backup of your database (this script will update rows).
+ *
+ * The script will only hash passwords that don't already look like
+ * a bcrypt hash (checks prefix $2y$ or $2b$).
+ */
+
+// Read DB connection from environment variables for safety.
+$dbHost = getenv('DB_HOST') ?: '127.0.0.1';
+$dbName = getenv('DB_NAME') ?: 'sports_club';
+$dbUser = getenv('DB_USER') ?: 'root';
+$dbPass = getenv('DB_PASS') ?: '';
+$dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
+
+echo "\n== Admin password migration script ==\n";
+echo "This script will convert plain-text admin passwords into bcrypt hashes.\n";
+echo "Make sure you have a DB backup before proceeding.\n\n";
+
+$confirm = readline("Type 'YES' to continue: ");
+if (trim($confirm) !== 'YES') {
+    echo "Aborted. No changes made.\n";
+    exit(0);
+}
+
+try {
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+} catch (PDOException $e) {
+    fwrite(STDERR, "DB connection failed: " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$select = $pdo->query("SELECT id, username, pass_key FROM admin");
+$admins = $select->fetchAll(PDO::FETCH_ASSOC);
+
+if (!$admins) {
+    echo "No admin rows found in 'admin' table.\n";
+    exit(0);
+}
+
+$updated = 0;
+foreach ($admins as $row) {
+    $id = $row['id'];
+    $username = $row['username'];
+    $pass = $row['pass_key'];
+
+    // naive check for bcrypt hash: starts with $2y$ or $2b$
+    if (preg_match('/^\$2[aby]\$\d{2}\$/', $pass)) {
+        echo "[OK] id=$id username=$username already hashed.\n";
+        continue;
+    }
+
+    echo "Hashing password for id=$id username=$username... ";
+    $hash = password_hash($pass, PASSWORD_BCRYPT);
+    if ($hash === false) {
+        echo "FAILED\n";
+        continue;
+    }
+
+    $stmt = $pdo->prepare('UPDATE admin SET pass_key = :hash WHERE id = :id');
+    $stmt->execute([':hash' => $hash, ':id' => $id]);
+    echo "done.\n";
+    $updated++;
+}
+
+echo "\nMigration complete. $updated account(s) updated.\n";
+echo "Remember to revoke access to this script after use.\n";
+
+?>

--- a/tools/secure_login_example.php
+++ b/tools/secure_login_example.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * secure_login_example.php
+ *
+ * Minimal example showing how to safely authenticate an admin user
+ * using PDO prepared statements and password_verify().
+ *
+ * This is an example only — adapt paths, session handling and error
+ * management to your project.
+ */
+
+// Load DB settings from env (or replace with your config loader)
+$dbHost = getenv('DB_HOST') ?: '127.0.0.1';
+$dbName = getenv('DB_NAME') ?: 'sports_club';
+$dbUser = getenv('DB_USER') ?: 'root';
+$dbPass = getenv('DB_PASS') ?: '';
+$dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
+
+try {
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+} catch (PDOException $e) {
+    die('DB connection failed');
+}
+
+// Example: process POST login
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    $stmt = $pdo->prepare('SELECT id, username, pass_key FROM admin WHERE username = :username LIMIT 1');
+    $stmt->execute([':username' => $username]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($user && password_verify($password, $user['pass_key'])) {
+        // Regenerate session id, set session vars, etc.
+        session_start();
+        session_regenerate_id(true);
+        $_SESSION['admin_id'] = $user['id'];
+        $_SESSION['admin_user'] = $user['username'];
+        echo "Login OK\n";
+    } else {
+        echo "Invalid credentials\n";
+    }
+    exit;
+}
+
+// Simple HTML form for manual testing
+?>
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Login example</title></head>
+<body>
+<form method="post">
+  <label>Username: <input name="username"></label><br>
+  <label>Password: <input name="password" type="password"></label><br>
+  <button type="submit">Login</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a one-time migration script to convert plain-text admin passwords into bcrypt hashes and provides a small secure-login example demonstrating PDO prepared statements + password_verify().\n\nFiles added:\n- tools/migrate_admin_passwords.php (migration helper)\n- tools/secure_login_example.php (login example)\n- README.md (migration instructions)\n\nHow to test locally:\n1. Backup your DB.\n2. Export DB connection environment variables and run the migration script (see README).\n3. Verify admin.pass_key now contains bcrypt hashes and that secure_login_example.php can authenticate using password_verify().\n\nThis is a focused, low-risk security improvement — recommend reviewing and running the migration in a safe environment first.